### PR TITLE
Patch boundary treatment

### DIFF
--- a/watercoupler/coupler/_coupler_initialize.py
+++ b/watercoupler/coupler/_coupler_initialize.py
@@ -73,7 +73,7 @@ def adcircgssha_coupler_initialize(self, argc, argv):
     #SET UP COUPLED STRUCT.
     ######################################################
     self.couplingtype=argv[argc.value-3]
-    self.couplingdtfactor = 480
+    #self.couplingdtfactor = 480 #in case of original Gal-brays-coupling
     self.adcircrunflag=pu.on
     self.adcirctstart=0.+self.pg.statim*86400.0 #statim is in days.
     self.adcircdt=0.+self.pg.dt*float(self.couplingdtfactor) #Needed 0+ to prevent the two from being the same object :-/ Careful!!!!
@@ -85,7 +85,8 @@ def adcircgssha_coupler_initialize(self, argc, argv):
     self.adcircfort20pathname=''.join(np.append(np.char.strip(self.ps.inputdir),'/fort.20.new.'+self.couplingtype))
     self.adcircedgestringid=int(argv[argc.value-4])-1
     self.adcircedgestringnnodes=self.pb.nvell[self.adcircedgestringid]
-    self.adcircedgestringnodes=self.pb.nbvv[1:self.adcircedgestringnnodes]
+    # We are only accounting for open boundaries and not for closed loops here:
+    self.adcircedgestringnodes=self.pb.nbvv[self.adcircedgestringid][1:self.adcircedgestringnnodes+1]
     self.gssharunflag=gsshadefine.ON
     self.gsshatstartjul=self.mvs[0].btime # in Julian date
     self.gsshadt=self.mvs[0].dt # in seconds

--- a/watercoupler/coupler/_coupler_initialize.py
+++ b/watercoupler/coupler/_coupler_initialize.py
@@ -73,7 +73,7 @@ def adcircgssha_coupler_initialize(self, argc, argv):
     #SET UP COUPLED STRUCT.
     ######################################################
     self.couplingtype=argv[argc.value-3]
-    #self.couplingdtfactor = 480 #in case of original Gal-brays-coupling
+    self.couplingdtfactor = 480 #in case of original Gal-brays-coupling
     self.adcircrunflag=pu.on
     self.adcirctstart=0.+self.pg.statim*86400.0 #statim is in days.
     self.adcircdt=0.+self.pg.dt*float(self.couplingdtfactor) #Needed 0+ to prevent the two from being the same object :-/ Careful!!!!

--- a/watercoupler/coupler/adcirc_init_bc_func.py
+++ b/watercoupler/coupler/adcirc_init_bc_func.py
@@ -20,10 +20,11 @@ def adcirc_init_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct
 
     ######################################################
     # Store the length of the coupled ADCIRC edge string
+    # Valid only for open boundary and not a closed one!
     for inode in range(1,ags.adcircedgestringnnodes):
         # -1 needed below since Python is 0 indexed whereas Fortan node numbers are 1-indexed
-        n1 = ags.pb.nbvv[ags.adcircedgestringid][inode  ]-1
-        n2 = ags.pb.nbvv[ags.adcircedgestringid][inode+1]-1
+        n1 = ags.adcircedgestringnodes[inode-1]-1
+        n2 = ags.adcircedgestringnodes[inode  ]-1
         x1 = ags.pm.x[n1]
         y1 = ags.pm.y[n1]
         x2 = ags.pm.x[n2]

--- a/watercoupler/coupler/adcirc_set_bc_func.py
+++ b/watercoupler/coupler/adcirc_set_bc_func.py
@@ -127,7 +127,7 @@ def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
     else:
         # Shift values backward
         ags.pg.qtime1 = ags.pg.qtime2
-        for i in range(ags.pb.nvel*2):
+        for i in range(ags.pb.nvel):
             ags.pg.qnin1[i] = ags.pg.qnin2[i]
         # Replace the fort.20 file.
         with open(ags.adcircfort20pathname, 'w') as fort20file:

--- a/watercoupler/coupler/adcircgsshastruct.py
+++ b/watercoupler/coupler/adcircgsshastruct.py
@@ -61,6 +61,7 @@ class adcircgsshastruct(): #Note: This is not a ctypes Structure!!!!
         self.adcircseries=0
         self.adcircedgestringid=self.pu.unset_int
         self.adcircedgestringnnodes=self.pu.unset_int
+        self.adcircedgestringnodes=[]
         self.adcircedgestringlen=0.0
         self.adcircfort20pathname=''
         self.adcirc_hprev=0.0   # Avg depth

--- a/watercoupler/coupler/gssha_init_bc_func.py
+++ b/watercoupler/coupler/gssha_init_bc_func.py
@@ -30,9 +30,9 @@ def gssha_init_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
     my_min_eta =  1.0e+200
     count=0.0
 
-    for inode in range(1,ags.adcircedgestringnnodes+1):
+    for inode in range(ags.adcircedgestringnnodes):
         # -1 needed below since Python is 0 indexed whereas Fortan node numbers are 1-indexed
-        node = ags.pb.nbvv[ags.adcircedgestringid][inode]-1
+        node = ags.adcircedgestringnodes[inode]-1
         eta = ags.pg.eta2[node]
         my_eta_sum += eta
         my_max_eta = max(my_max_eta, eta)

--- a/watercoupler/coupler/gssha_set_bc_func.py
+++ b/watercoupler/coupler/gssha_set_bc_func.py
@@ -38,9 +38,9 @@ def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
         my_avg_delta_eta=0.0
         my_eta_sum=0.0
 
-        for inode in range(1,ags.adcircedgestringnnodes+1):
+        for inode in range(ags.adcircedgestringnnodes):
             # -1 needed below since Python is 0 indexed whereas Fortan node numbers are 1-indexed
-            node = ags.pb.nbvv[ags.adcircedgestringid][inode]-1
+            node = ags.adcircedgestringnodes[inode]-1
             eta     = ags.pg.eta2[node]
             old_eta = ags.pg.eta1[node]
             my_eta_sum       += eta


### PR DESCRIPTION
This patch is to allow water-coupler to separately store ADCIRC's boundary nodes in separate variable. An out-of-bounds memory access was also fixed.