### PR TITLE
Enable pip-installation; Enable Python version-independence; Fix MPI calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,35 @@ parallel.
 
 ### Dependencies
 
-* [Python 2.7](https://www.python.org/downloads/release/python-2718/) - for now.
+* Python 2x or 3x (tested on 2.7 and 3.6),
 * [NumPy](https://numpy.org/)
-* ADCIRC shared library   : `libadcpy.so`
-* ADCIRC python interface : `pyadcirc.so`
+* ADCIRC shared libraries : `libadcpy.so`/`libpadcpy.so` and `pyadcirc.so`
+* ADCIRC python interface : `pyADCIRC`
 * GSSHA shared library    : `libgssha.so`
 * GSSHA python interface  : `gsshapython`
 
 ### Installing
 
-After setting up the prerequisites, open `watercoupler/__init__.py` and
-give the full path to the directory that contains `pyadcirc.so` and to the
-`gsshapython` directory. Open `watercoupler/__main__.py` and add the full path
-to the directory containing the `watercoupler` folder.
+After (pip-) installing the prerequisites, `pyADCIRC` and `gsshapython`,
+pip-install `watercoupler` as well, as follows:
+```bash
+cd <path_to_water-coupler_repo_root>
+python3 -m pip install .
+```
 
 ### Running tests
 
-Currently, no automated tests have been enabled for `watercoupler`.
+Currently, no automated tests have been enabled for `watercoupler`. However, a
+repository of testcases is being developed; see
+[water-coupler-tests](https://github.com/gajanan-choudhary/water-coupler-tests).
 
 
 ## Using the project
 
 Suppose you want to run a coupled ADCIRC-GSSHA simulation, with ADCIRC files
 named `fort.*` and GSSHA files named `Stream*`, including the project file
-`Stream.prj`. Copy the ADCIRC and GSSHA input files in a single directory. Copy
-or add a symlink/shortcut to `watercoupler/__main__.py` into this directory,
-naming it as, say, `watercoupler.py` and run the file. Run this file with
-command line arguments as follows.
+`Stream.prj`. Copy the ADCIRC and GSSHA input files in a single directory. Run
+`watercoupler` as a python module with the following command line arguments:
  - Argument 1: Boundary string ID of the ADCIRC model that is being coupled,
  - Argument 2: One of the following coupling type identifiers,
    * `Adg`   - One-way coupling with ADCIRC driving GSSHA,
@@ -45,27 +47,27 @@ command line arguments as follows.
    * `AdgdA` - Two-way coupling with ADCIRC "driving" (staying ahead of) GSSHA,
    * `gdAdg` - Two-way coupling with GSSHA "driving" (staying ahead of) ADCIRC,
  - Argument 3: Name of GSSHA Project file, e.g., `Stream.prj`, and
- - Argument 4: Name of ADCIRC Project file, e.g., `fort`.
+ - Argument 4: Name of ADCIRC Project file, e.g., `fort` (currently ignored).
+
 For instance, the Linux/Unix workflow goes as follows.
 ```bash
 mkdir sample-sim
 cd sample-sim
-cp <path_to_ADCIRC_input_files>/fort.* .
-cp <path_to_GSSHA_input_files>/Stream* .
-cp <path_to_watercoupler_folder>/__main__.py watercoupler.py
+cp -r <path_to_ADCIRC_input_files>/* .
+cp -r <path_to_GSSHA_input_files>/* .
 
-python watercoupler.py \
+python3 -m watercoupler \
     <ADCIRC model coupled boundary> \
     <Coupling type identifier> \
     <GSSHA project file name> \
     <ADCIRC project file name without extension>
 ```
 
-For parallel runs when ADCIRC has been compiled in parallel using OpenMPI, use
+For parallel runs when pyADCIRC has been compiled in parallel, you may run
+```bash
+mpirun  -np <num_procs>  python3 -m watercoupler.py  3  AdgdA  Stream.prj  fort
 ```
-mpirun  -np  <num_procs>  python  watercoupler.py  3  AdgdA  Stream.prj  fort
-```
-where `<num_procs>` is the number of processors you want to use.
+for instance, where `<num_procs>` is the number of MPI processes to be used.
 
 
 ## Authors
@@ -84,6 +86,6 @@ cannot and should not be distributed with this software.
 ## Acknowledgments
 
 * [f2py](https://numpy.org/doc/stable/f2py/) documentation
-* [ctypes](https://docs.python.org/2.7/library/ctypes.html) documentation
+* [ctypes](https://docs.python.org/3/library/ctypes.html) documentation
 * [Stackoverflow](https://stackoverflow.com/) community
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 from setuptools import setup, find_packages
 
@@ -20,7 +20,7 @@ setup(
     author_email='gajananchoudhary91@gmail.com',
     url='https://github.com/gajanan-choudhary/water-coupler',
     license=license,
-    packages=find_packages(exclude=('tests', 'doc')),
+    packages=find_packages(exclude=["*tests.*", "*tests", 'doc']),
     entry_points={'console_scripts': watercoupler_cmds},
     package_dir={'': '.'},
     package_data={'': []},

--- a/watercoupler/__init__.py
+++ b/watercoupler/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
@@ -9,10 +9,18 @@ The main watercoupler module.
 Contains the main watercoupler function imported as "main".
 """
 
+from __future__ import absolute_import, print_function
+
 if __name__ == '__main__':
-    import watercoupler_path
-    from main import main
+    import watercoupler_path as _watercoupler_path
 else:
-    from . import watercoupler_path
-    from .main import main
+    from . import watercoupler_path as _watercoupler_path
+
+from watercoupler.main import main
+
+__all__ = ['main', ]
+
+#------------------------------------------------------------------------------#
+if (__name__ == '__main__'):
+    pass
 

--- a/watercoupler/__main__.py
+++ b/watercoupler/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
@@ -7,14 +7,19 @@
 Main function of watercoupler that gets invoked on the command line.
 """
 
-if __name__ == "__main__":
-    import watercoupler_path
-    from main import main
+from __future__ import absolute_import
+
+if (__package__ == "watercoupler"):
+    from . import watercoupler_path as _watercoupler_path
+    from .main import main
+elif (__name__ == "__main__"):
+    import watercoupler_path as _watercoupler_path
+    from watercoupler.main import main
 else:
-    from . import watercoupler_path
+    from . import watercoupler_path as _watercoupler_path
     from .main import main
 
-################################################################################
+#------------------------------------------------------------------------------#
 if __name__ == '__main__':
     main()
 

--- a/watercoupler/coupler/_coupler_finalize.py
+++ b/watercoupler/coupler/_coupler_finalize.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 
-################################################################################
 import gsshapython.sclass.build_options as gsshaopts
 import gsshapython.sclass.define_h      as gsshadefine
 import gsshapython.sclass.fnctn_h       as gsshafnctn
@@ -16,18 +16,18 @@ DEBUG_LOCAL = 1
 def adcircgssha_coupler_finalize(self):
 
     if gsshaopts._DEBUG==gsshadefine.ON and DEBUG_LOCAL!=0 and self.myid==0:
-        print "Finalizing GSSHA"
+        print("Finalizing GSSHA")
     ierr_code = gsshafnctn.main_gssha_finalize(self.mvs)
     if self.myid==0:
-        print "*********************** GSSHA Finalized ***********************"
-        print "***************************************************************"
+        print("*********************** GSSHA Finalized ***********************")
+        print("***************************************************************")
 
     if self.pu.debug==self.pu.on and DEBUG_LOCAL!=0 and self.myid==0:
-        print '\n\nFinalizing ADCIRC\n'
+        print('\n\nFinalizing ADCIRC\n')
     ierr_code = self.pmain.pyadcirc_finalize()
     if self.myid==0:
-        print "********************** ADCIRC Finalized ***********************"
-        print "***************************************************************"
+        print("********************** ADCIRC Finalized ***********************")
+        print("***************************************************************")
 
 
 ################################################################################

--- a/watercoupler/coupler/_coupler_run.py
+++ b/watercoupler/coupler/_coupler_run.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 
 from ctypes import c_double as ctypes_c_double
 
@@ -13,10 +14,10 @@ import gsshapython.sclass.define_h      as gsshadefine
 import gsshapython.sclass.fnctn_h       as gsshafnctn
 
 ################################################################################
-from adcirc_init_bc_func import adcirc_init_bc_from_gssha_hydrograph
-from adcirc_set_bc_func  import adcirc_set_bc_from_gssha_hydrograph
-from gssha_init_bc_func  import gssha_init_bc_from_adcirc_depths
-from gssha_set_bc_func   import gssha_set_bc_from_adcirc_depths
+from .adcirc_init_bc_func import adcirc_init_bc_from_gssha_hydrograph
+from .adcirc_set_bc_func  import adcirc_set_bc_from_gssha_hydrograph
+from .gssha_init_bc_func  import gssha_init_bc_from_adcirc_depths
+from .gssha_set_bc_func   import gssha_set_bc_from_adcirc_depths
 
 ################################################################################
 DEBUG_LOCAL = 1
@@ -34,7 +35,7 @@ DEBUG_LOCAL = 1
 #########################################################################functag
 def coupler_run_gssha_driving_adcirc(ags):
 
-    from adcircgsshastruct     import TIME_TOL
+    from .adcircgsshastruct     import TIME_TOL
 
     adcirc_init_bc_from_gssha_hydrograph(ags)
     if ags.couplingtype == 'gdAdg':
@@ -53,10 +54,10 @@ def coupler_run_gssha_driving_adcirc(ags):
         ags.mvs[0].go    = gsshatypes.FALSE
     if ags.pu.messg == ags.pu.on:
         if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-            print 'PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer
+            print('PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer)
         ags.mvs[0].timer = ags.pmsg.pymsg_dbl_max(ags.mvs[0].timer, ags.adcirc_comm_comp)
         if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-            print 'PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer
+            print('PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer)
 
     while (ags.adcirctprev<ags.adcirctfinal or ags.mvs[0].timer<ags.gsshatfinal):
         ######################################################
@@ -83,14 +84,14 @@ def coupler_run_gssha_driving_adcirc(ags):
                 ags.mvs[0].single_event_end = ags.mvs[0].b_lt_start + ags.mvs[0].niter/1440.0 #gsshatfinal was original niter in mins
 
             if gsshaopts._DEBUG == gsshadefine.ON and DEBUG_LOCAL != 0 and ags.myid == 0:
-                print "\n*******************************************\nRunning GSSHA:"
-                print "dt             =", ags.mvs[0].dt
-                print "timer          =", ags.mvs[0].timer
-                print "niter          =", ags.mvs[0].niter
-                print "superdt        =", superdt
-                print "end time       =", ags.mvs[0].timer*ags.gsshatimefact + superdt
+                print("\n*******************************************\nRunning GSSHA:")
+                print("dt             =", ags.mvs[0].dt)
+                print("timer          =", ags.mvs[0].timer)
+                print("niter          =", ags.mvs[0].niter)
+                print("superdt        =", superdt)
+                print("end time       =", ags.mvs[0].timer*ags.gsshatimefact + superdt)
             elif ags.myid==0:
-                print "\n*******************************************\nRunning GSSHA:"
+                print("\n*******************************************\nRunning GSSHA:")
 
             # Run GSSHA only on 1 processsor: PE 0.
             if ags.myid == 0:
@@ -104,10 +105,10 @@ def coupler_run_gssha_driving_adcirc(ags):
                 ags.mvs[0].go    = gsshatypes.FALSE
             if ags.pu.messg == ags.pu.on:
                 if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-                    print 'PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer
+                    print('PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer)
                 ags.mvs[0].timer = ags.pmsg.pymsg_dbl_max(ctypes_c_double(ags.mvs[0].timer), ags.adcirc_comm_comp)
                 if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-                    print 'PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer
+                    print('PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer)
 
         else:
             ags.gssharunflag = gsshadefine.OFF
@@ -128,13 +129,13 @@ def coupler_run_gssha_driving_adcirc(ags):
                 ags.adcirctnext = ags.adcirctfinal
 
             if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0 and ags.myid == 0:
-                print "\n****************************************\nRunning ADCIRC:"
-                print "dt             =", ags.adcircdt
-                print "t_prev         =", ags.adcirctprev
-                print "t_final        =", ags.adcirctnext
-                print "ntsteps        =", ntsteps
+                print("\n****************************************\nRunning ADCIRC:")
+                print("dt             =", ags.adcircdt)
+                print("t_prev         =", ags.adcirctprev)
+                print("t_final        =", ags.adcirctnext)
+                print("ntsteps        =", ntsteps)
             elif ags.myid==0:
-                print "\n****************************************\nRunning ADCIRC:"
+                print("\n****************************************\nRunning ADCIRC:")
 
             # Run ADCIRC
             ags.pmain.pyadcirc_run(ntsteps)
@@ -151,7 +152,7 @@ def coupler_run_gssha_driving_adcirc(ags):
 #########################################################################functag
 def coupler_run_adcirc_driving_gssha(ags):
 
-    from adcircgsshastruct     import TIME_TOL
+    from .adcircgsshastruct     import TIME_TOL
 
     gssha_init_bc_from_adcirc_depths(ags)
     if ags.couplingtype == 'AdgdA':
@@ -170,10 +171,10 @@ def coupler_run_adcirc_driving_gssha(ags):
         ags.mvs[0].go    = gsshatypes.FALSE
     if ags.pu.messg == ags.pu.on:
         if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-            print 'PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer
+            print('PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer)
         ags.mvs[0].timer = ags.pmsg.pymsg_dbl_max(ags.mvs[0].timer, ags.adcirc_comm_comp)
         if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-            print 'PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer
+            print('PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer)
 
     while (ags.adcirctprev<ags.adcirctfinal or ags.mvs[0].timer<ags.gsshatfinal):
         ######################################################
@@ -188,13 +189,13 @@ def coupler_run_adcirc_driving_gssha(ags):
                 ags.adcirctnext = ags.adcirctfinal
 
             if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0 and ags.myid == 0:
-                print "\n****************************************\nRunning ADCIRC:"
-                print "dt             =", ags.adcircdt
-                print "t_prev         =", ags.adcirctprev
-                print "t_final        =", ags.adcirctnext
-                print "ntsteps        =", ntsteps
+                print("\n****************************************\nRunning ADCIRC:")
+                print("dt             =", ags.adcircdt)
+                print("t_prev         =", ags.adcirctprev)
+                print("t_final        =", ags.adcirctnext)
+                print("ntsteps        =", ntsteps)
             elif ags.myid==0:
-                print "\n****************************************\nRunning ADCIRC:"
+                print("\n****************************************\nRunning ADCIRC:")
 
             # Run ADCIRC
             ags.pmain.pyadcirc_run(ntsteps)
@@ -231,14 +232,14 @@ def coupler_run_adcirc_driving_gssha(ags):
                 ags.mvs[0].single_event_end = ags.mvs[0].b_lt_start + ags.mvs[0].niter/1440.0 #gsshatfinal was original niter in mins
 
             if gsshaopts._DEBUG == gsshadefine.ON and DEBUG_LOCAL != 0 and ags.myid == 0:
-                print "\n*******************************************\nRunning GSSHA:"
-                print "dt             =", ags.mvs[0].dt
-                print "timer          =", ags.mvs[0].timer
-                print "niter          =", ags.mvs[0].niter
-                print "superdt        =", superdt
-                print "end time       =", ags.mvs[0].timer*ags.gsshatimefact + superdt
+                print("\n*******************************************\nRunning GSSHA:")
+                print("dt             =", ags.mvs[0].dt)
+                print("timer          =", ags.mvs[0].timer)
+                print("niter          =", ags.mvs[0].niter)
+                print("superdt        =", superdt)
+                print("end time       =", ags.mvs[0].timer*ags.gsshatimefact + superdt)
             elif ags.myid==0:
-                print "\n*******************************************\nRunning GSSHA:"
+                print("\n*******************************************\nRunning GSSHA:")
 
             # Run GSSHA only on 1 processsor: PE 0.
             if ags.myid == 0:
@@ -252,10 +253,10 @@ def coupler_run_adcirc_driving_gssha(ags):
                 ags.mvs[0].go    = gsshatypes.FALSE
             if ags.pu.messg == ags.pu.on:
                 if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-                    print 'PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer
+                    print('PE[',ags.myid,'] Before messg: timer = ', ags.mvs[0].timer)
                 ags.mvs[0].timer = ags.pmsg.pymsg_dbl_max(ctypes_c_double(ags.mvs[0].timer), ags.adcirc_comm_comp)
                 if (ags.pu.debug ==ags.pu.on or DEBUG_LOCAL != 0):
-                    print 'PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer
+                    print('PE[',ags.myid,'] After messg : timer = ', ags.mvs[0].timer)
 
         else:
             ags.gssharunflag = gsshadefine.OFF
@@ -287,22 +288,22 @@ def adcircgssha_coupler_run(self):
         run_func = coupler_run_adcirc_driving_gssha
 
     else:
-        print 'Unkown coupling type supplied by user:', self.couplingtype, '\nExiting.'
+        print('Unkown coupling type supplied by user:', self.couplingtype, '\nExiting.')
         return
 
-    print "\n\n***************************************************************"
-    print     "***************************************************************"
-    print     run_string
-    print     "***************************************************************"
-    print     "***************************************************************"
+    print("\n\n***************************************************************")
+    print(    "***************************************************************")
+    print(    run_string)
+    print(    "***************************************************************")
+    print(    "***************************************************************")
 
     run_func(self)
 
-    print "\n\n***************************************************************"
-    print     "***************************************************************"
-    print     "Finished", run_string
-    print     "***************************************************************"
-    print     "***************************************************************"
+    print("\n\n***************************************************************")
+    print(    "***************************************************************")
+    print(    "Finished", run_string)
+    print(    "***************************************************************")
+    print(    "***************************************************************")
 
 
 #########################################################################functag

--- a/watercoupler/coupler/adcirc_init_bc_func.py
+++ b/watercoupler/coupler/adcirc_init_bc_func.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 import numpy as np
 
 ################################################################################
@@ -11,7 +12,7 @@ DEBUG_LOCAL = 1
 ################################################################################
 def adcirc_init_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
 
-    from adcircgsshastruct import SERIESLENGTH, TIME_TOL
+    from .adcircgsshastruct import SERIESLENGTH, TIME_TOL
 
     ######################################################
     #SET UP ADCIRC BC series and edgestring.
@@ -33,11 +34,11 @@ def adcirc_init_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct
         dely = y2-y1
         ags.adcircedgestringlen += np.sqrt(delx*delx+dely*dely)
         if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0:
-            print "Nodes ",n1,"(",x1,",",y1,"),",n2,"(",x2,",",y2,")"
+            print("Nodes ",n1,"(",x1,",",y1,"),",n2,"(",x2,",",y2,")")
     if ags.pu.messg==ags.pu.on:
-        ags.adcircedgestringlen = ags.pmsg.pymessg_dbl_sum(ags.adcircedgestringlen, ags.adcirc_comm_comp)
+        ags.adcircedgestringlen = ags.pmsg.pymsg_dbl_sum(ags.adcircedgestringlen, ags.adcirc_comm_comp)
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0:
-        print "Edge string(",ags.adcircedgestringid+1,"): Length = ", ags.adcircedgestringlen
+        print("Edge string(",ags.adcircedgestringid+1,"): Length = ", ags.adcircedgestringlen)
 
     ######################################################
     # Find series to modify during coupling.
@@ -45,11 +46,11 @@ def adcirc_init_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct
 
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0 and ags.myid==0:
         nbvStartIndex=sum(ags.pb.nvell[:ags.adcircedgestringid])
-        print "Original: Flux time increment FTIMINC =", ags.pg.ftiminc,\
+        print("Original: Flux time increment FTIMINC =", ags.pg.ftiminc,\
                 "\nOriginal: Flux times:\nQTIME1 =", ags.pg.qtime1, \
                 "\nQTIME2 =", ags.pg.qtime2, \
                 "\nOriginal: Flux values:\nQNIN1  =\n",  ags.pg.qnin1[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes], \
-                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]
+                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes])
 
     ##################################################
     # Replace the flux time increment value.
@@ -115,11 +116,11 @@ def adcirc_init_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct
                                                ## Ensure this gets replaced in set_bc function.
 
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0:
-        print "Replaced: Flux time increment FTIMINC =", ags.pg.ftiminc,\
+        print("Replaced: Flux time increment FTIMINC =", ags.pg.ftiminc,\
                 "\nReplaced: Flux times:\nQTIME1 =", ags.pg.qtime1, \
                 "\nQTIME2 =", ags.pg.qtime2, \
                 "\nReplaced: Flux values:\nQNIN1  =\n",  ags.pg.qnin1[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes], \
-                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]
+                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes])
 
 ################################################################################
 if __name__ == '__main__':

--- a/watercoupler/coupler/adcirc_set_bc_func.py
+++ b/watercoupler/coupler/adcirc_set_bc_func.py
@@ -1,29 +1,29 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 
-############################################################################################################################################################
 import gsshapython.sclass.build_options as gsshaopts
 import gsshapython.sclass.define_h      as gsshadefine
 
-############################################################################################################################################################
+################################################################################
 DEBUG_LOCAL = 1
-############################################################################################################
+################################################################################
 def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
 
-    from adcircgsshastruct import SERIESLENGTH, TIME_TOL
+    from .adcircgsshastruct import SERIESLENGTH, TIME_TOL
 
     ########## Set ADCIRC Boundary Conditions ###########
     # Note: ags.adcircseries already points to the head of series in ADCIRC that needs to be modified.
     nbvStartIndex=sum(ags.pb.nvell[:ags.adcircedgestringid])
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0 and ags.myid==0:
-        print "\nOriginal: Flux time increment FTIMINC =", ags.pg.ftiminc,\
+        print("\nOriginal: Flux time increment FTIMINC =", ags.pg.ftiminc,\
                 "\nOriginal: Flux times:\nQTIME1 =", ags.pg.qtime1, \
                 "\nQTIME2 =", ags.pg.qtime2, \
                 "\nOriginal: Flux values:\nQNIN1  =\n",  ags.pg.qnin1[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes], \
-                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]
+                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes])
 
     if ags.pu.messg == ags.pu.on:
         if ags.myid != 0:
@@ -31,10 +31,10 @@ def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
         else:
             messgvout  = ags.mvs[0].vout
         if (ags.pu.debug ==ags.pu.on or gsshaopts._DEBUG == gsshadefine.ON) or DEBUG_LOCAL != 0:
-            print 'PE[',ags.myid,'] Before messg: vout = ', ags.mvs[0].vout
-        ags.mvs[0].vout  = ags.pmsg.pymessg_dbl_max(messgvout, ags.adcirc_comm_comp)
+            print('PE[',ags.myid,'] Before messg: vout = ', ags.mvs[0].vout)
+        ags.mvs[0].vout  = ags.pmsg.pymsg_dbl_max(messgvout, ags.adcirc_comm_comp)
         if (ags.pu.debug ==ags.pu.on or gsshaopts._DEBUG == gsshadefine.ON) or DEBUG_LOCAL != 0:
-            print 'PE[',ags.myid,'] After messg : vout = ', ags.mvs[0].vout
+            print('PE[',ags.myid,'] After messg : vout = ', ags.mvs[0].vout)
 
     ######################################################
     # Close the original fort.20
@@ -59,19 +59,19 @@ def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
             # This is valid only for PE 0 which is running GSSHA. Not on other PEs!
             outlet_area  = ags.mvs[0].area[      ags.mvs[0].nx[ags.mvs[0].nlinks]][ags.mvs[0].nlinks]
             outlet_depth = ags.mvs[0].chan_depth[ags.mvs[0].nx[ags.mvs[0].nlinks]][ags.mvs[0].nlinks]
-            print"outlet area       =", outlet_area, "m2"
-            print"outlet chan_depth =", outlet_depth, "m"
-            print"qout              =", ags.mvs[0].qout, "m3/s"
-            print"voutprev          =", ags.gsshavoutprev, "m3"
-            print"vout              =", ags.mvs[0].vout, "m3"
-            print"DV                =", DV, "m3"
-            print"DT                =", DT, "s"
-            print"GSSHA qout/area   =", ags.mvs[0].qout / outlet_area,"m/s"
-            print"Avg. GSSHA speed  ~", DV / DT / outlet_area, "m/s"
-            print"Avg. ADCIRC speed ~", DV / DT, "(m3/s) / ADCIRC area (needs more work!)"
+            print("outlet area       =", outlet_area, "m2")
+            print("outlet chan_depth =", outlet_depth, "m")
+            print("qout              =", ags.mvs[0].qout, "m3/s")
+            print("voutprev          =", ags.gsshavoutprev, "m3")
+            print("vout              =", ags.mvs[0].vout, "m3")
+            print("DV                =", DV, "m3")
+            print("DT                =", DT, "s")
+            print("GSSHA qout/area   =", ags.mvs[0].qout / outlet_area,"m/s")
+            print("Avg. GSSHA speed  ~", DV / DT / outlet_area, "m/s")
+            print("Avg. ADCIRC speed ~", DV / DT, "(m3/s) / ADCIRC area (needs more work!)")
 
         if DV < 0.0:
-            print"Warning: Outflow from ADCIRC model forced by GSSHA! This can cause instabilities in the model!"
+            print("Warning: Outflow from ADCIRC model forced by GSSHA! This can cause instabilities in the model!")
 
         # Move current to previous: Current is at [2], previous is at [1]
         # Shift values backward
@@ -86,7 +86,7 @@ def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
 
         # ADCIRC Series value
         #DT_calculated = ags.adcircseries[0].entry[SERIESLENGTH-2].time - ags.adcircseries[0].entry[SERIESLENGTH-3].time
-        #print"DT_calculated     =", DT_calculated, "s"
+        #print("DT_calculated     =", DT_calculated, "s")
         #DT_calculated affects how the mass is distributed. If we want to dump all the mass from GSSHA into ADCIRC's next time step
         #no matter how large it may be, we should use DT_calculated. For now, I'm skipping DT_calculated.
         oldseriesvalue = ags.pg.qnin2[nbvStartIndex]
@@ -94,7 +94,7 @@ def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
         seriesvalue =  ags.mvs[0].qout/ags.adcircedgestringlen
         ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes] = seriesvalue
         with open(ags.adcircfort20pathname, 'w') as fort20file:
-            #print "QNIN values start at", nbvStartIndex
+            #print("QNIN values start at", nbvStartIndex)
             for i in range(ags.pb.nvel):
                 if ags.pb.lbcodei[i] in [2, 12, 22]:
                     [fort20file.write('{0:10f}\n'.format(ags.pg.qnin2[i]))]
@@ -142,13 +142,13 @@ def adcirc_set_bc_from_gssha_hydrograph(ags): # ags is of type adcircgsshatruct.
     assert(errorio==0)
 
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0:
-        print "Replaced: Flux time increment FTIMINC =", ags.pg.ftiminc,\
+        print("Replaced: Flux time increment FTIMINC =", ags.pg.ftiminc,\
                 "\nReplaced: Flux times:\nQTIME1 =", ags.pg.qtime1, \
                 "\nQTIME2 =", ags.pg.qtime2, \
                 "\nReplaced: Flux values:\nQNIN1  =\n",  ags.pg.qnin1[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes], \
-                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]
-        print 'Area   contained  =', ags.adcircseriesarea
-        print 'Volume contained  =', ags.adcircseriesarea*ags.adcircedgestringlen
+                "\nQNIN2  =\n",  ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes])
+        print('Area   contained  =', ags.adcircseriesarea)
+        print('Volume contained  =', ags.adcircseriesarea*ags.adcircedgestringlen)
 
 
 ############################################################################################################

--- a/watercoupler/coupler/adcircgsshastruct.py
+++ b/watercoupler/coupler/adcircgsshastruct.py
@@ -3,20 +3,12 @@
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 import sys
 import ctypes as ct
 
-################################################################################
-import pyadcirc as pa
-#ps    = pa.sizes
-#pg    = pa.pyglobal
-#pm    = pa.pymesh
-#pmsg  = pa.pymessenger
-#pb    = pa.pyboundaries
-#pmain = pa.pyadcirc_mod
-#pu    = pa.utilities
+from pyADCIRC import pyadcirc as pa
 
-################################################################################
 import gsshapython.sclass.define_h      as gsshadefine
 import gsshapython.sclass.fnctn_h       as gsshafnctn
 import gsshapython.sclass.main_struct_h as gsshamain
@@ -80,9 +72,9 @@ class adcircgsshastruct(): #Note: This is not a ctypes Structure!!!!
         self.gsshatimefact=GSSHA_TIME_FACTOR ## Minutes to seconds conversion, since niter is in mins.
         self.gsshahydrofact=1.0 # GSSHA_CUFTPERSEC_TO_CUMPERSEC may not be required after all since GSSHA internally seems to use cu.m/s.
 
-    from _coupler_initialize import adcircgssha_coupler_initialize as coupler_initialize
-    from _coupler_run import adcircgssha_coupler_run as coupler_run
-    from _coupler_finalize import adcircgssha_coupler_finalize as coupler_finalize
+    from ._coupler_initialize import adcircgssha_coupler_initialize as coupler_initialize
+    from ._coupler_run import adcircgssha_coupler_run as coupler_run
+    from ._coupler_finalize import adcircgssha_coupler_finalize as coupler_finalize
 
 
 ################################################################################
@@ -92,17 +84,18 @@ if __name__=='__main__':
     ct.pythonapi.Py_GetArgcArgv(ct.byref(argc), ct.byref(argv))
 
     if DEBUG_LOCAL == 1:
-        print 'Number of arguments passed to python:', argc.value, '\nArgs:',
-        for i in range(argc.value):
-            print argv[i],
-        print
+        print('Number of arguments passed to python: {0} \nArgs:'.format(
+            argc.value), end = '')
+        [print(argv[i], end = ' ') for i in range(argc.value)]
+        print()
     if argc.value>=6:
-        print "ADCIRC project   :", argv[argc.value-1]
-        print "GSSHA project :", argv[argc.value-2]
+        print("ADCIRC project:", argv[argc.value-1])
+        print("GSSHA project :", argv[argc.value-2])
         ags = adcircgsshastruct()
         ags.coupler_initialize(argc, argv)
         ags.coupler_run()
         ags.coupler_finalize()
     else:
-        print("\nPath to ADCIRC and GSSHA input files not specified.\nExiting without testing.")
+        print("\nPath to ADCIRC and GSSHA input files not specified."
+              "\nExiting without testing.")
 

--- a/watercoupler/coupler/gssha_init_bc_func.py
+++ b/watercoupler/coupler/gssha_init_bc_func.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 
-################################################################################
 import gsshapython.sclass.build_options   as gsshaopts
 import gsshapython.sclass.define_h        as gsshadefine
 import gsshapython.sclass.fnctn_h         as gsshafnctn
@@ -41,10 +41,10 @@ def gssha_init_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
 
     # Note: Hoping whichever depth is closes to GSSHA current depth works better in damping oscillations than dmax alone!
     if (ags.pu.messg==ags.pu.on):
-        eta_sum = ags.pmsg.pymessg_dbl_sum(my_eta_sum, ags.adcirc_comm_comp)
-        max_eta = ags.pmsg.pymessg_dbl_max(my_max_eta, ags.adcirc_comm_comp)
-        min_eta = ags.pmsg.pymessg_dbl_min(my_min_eta, ags.adcirc_comm_comp)
-        count    = ags.pmsg.pymessg_dbl_sum(count      , ags.adcirc_comm_comp)
+        eta_sum = ags.pmsg.pymsg_dbl_sum(my_eta_sum, ags.adcirc_comm_comp)
+        max_eta = ags.pmsg.pymsg_dbl_max(my_max_eta, ags.adcirc_comm_comp)
+        min_eta = ags.pmsg.pymsg_dbl_min(my_min_eta, ags.adcirc_comm_comp)
+        count   = ags.pmsg.pymsg_dbl_sum(count     , ags.adcirc_comm_comp)
     else:
         eta_sum = my_eta_sum
         max_eta = my_max_eta
@@ -52,15 +52,15 @@ def gssha_init_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
     avg_eta = eta_sum/count
     ags.adcirc_hprev = avg_eta # Going to be taking the average.
     ags.adcirc_hprev_len = count # Going to be taking the average.
-    print "PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Starting Average eta2 = ", ags.adcirc_hprev, "count = ", ags.adcirc_hprev_len
+    print("PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Starting Average eta2 = ", ags.adcirc_hprev, "count = ", ags.adcirc_hprev_len)
 
 
     ######################################################
     ts = ags.mvs[0].bound_ts_ptr[0]
     if (ags.pu.debug == ags.pu.on or gsshaopts._DEBUG == gsshadefine.ON) and DEBUG_LOCAL != 0 and ags.myid == 0:
-        print '\nSetting up Boundary time series for GSSHA.'
+        print('\nSetting up Boundary time series for GSSHA.')
         for i in range(ts.num_vals):
-            print'Before:(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')'
+            print('Before:(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')')
 
     superdt = 0.0
     while (superdt < ags.adcirctstart + ags.adcircdt):
@@ -78,7 +78,7 @@ def gssha_init_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
 
     if (ags.pu.debug == ags.pu.on or gsshaopts._DEBUG == gsshadefine.ON) and DEBUG_LOCAL != 0 and ags.myid == 0:
         for i in range(ts.num_vals):
-            print'After :(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')'
+            print('After :(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')')
     #exit()
 
 ################################################################################

--- a/watercoupler/coupler/gssha_set_bc_func.py
+++ b/watercoupler/coupler/gssha_set_bc_func.py
@@ -1,19 +1,19 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
+from __future__ import absolute_import, print_function
 
-############################################################################################################################################################
 import gsshapython.sclass.build_options   as gsshaopts
 import gsshapython.sclass.define_h        as gsshadefine
 import gsshapython.sclass.fnctn_h         as gsshafnctn
 from gsshapython.sclass.timeseriesdefs_h import ts_struct
 
-############################################################################################################################################################
+################################################################################
 DEBUG_LOCAL = 1
 
-############################################################################################################
+################################################################################
 def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
 
     from adcircgsshastruct import SERIESLENGTH, TIME_TOL
@@ -23,9 +23,9 @@ def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
     ts = ags.mvs[0].bound_ts_ptr[0]
 
     if (ags.pu.debug ==ags.pu.on or gsshaopts._DEBUG == gsshadefine.ON) and DEBUG_LOCAL != 0 and ags.myid == 0:
-        print
+        print()
         for i in range(ts.num_vals):
-            print'Before:(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')'
+            print('Before:(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')')
 
     ######################################################
     #SET UP gssha BC from ADCIRC.
@@ -52,11 +52,11 @@ def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
 
         # Note: Hoping whichever depth is closes to GSSHA current depth works better in damping oscillations than dmax alone!
         if (ags.pu.messg==ags.pu.on):
-            eta_sum       = ags.pmsg.pymessg_dbl_sum(my_eta_sum      , ags.adcirc_comm_comp)
-            avg_delta_eta = ags.pmsg.pymessg_dbl_sum(my_avg_delta_eta, ags.adcirc_comm_comp)
-            max_delta_eta = ags.pmsg.pymessg_dbl_max(my_max_delta_eta, ags.adcirc_comm_comp)
-            min_delta_eta = ags.pmsg.pymessg_dbl_min(my_min_delta_eta, ags.adcirc_comm_comp)
-            count         = ags.pmsg.pymessg_dbl_sum(count           , ags.adcirc_comm_comp)
+            eta_sum       = ags.pmsg.pymsg_dbl_sum(my_eta_sum      , ags.adcirc_comm_comp)
+            avg_delta_eta = ags.pmsg.pymsg_dbl_sum(my_avg_delta_eta, ags.adcirc_comm_comp)
+            max_delta_eta = ags.pmsg.pymsg_dbl_max(my_max_delta_eta, ags.adcirc_comm_comp)
+            min_delta_eta = ags.pmsg.pymsg_dbl_min(my_min_delta_eta, ags.adcirc_comm_comp)
+            count         = ags.pmsg.pymsg_dbl_sum(count           , ags.adcirc_comm_comp)
         else:
             eta_sum       = my_eta_sum
             avg_delta_eta = my_avg_delta_eta
@@ -70,10 +70,10 @@ def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
         ags.adcirc_hprev_len = count
 
         if ags.pu.debug == ags.pu.on or DEBUG_LOCAL != 0:
-            print "PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Average eta = ", avg_eta
-            print "PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Maximum delta_eta = ", max_delta_eta
-            print "PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Minimum delta_eta = ", min_delta_eta
-            print "PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Average delta_eta = ", avg_delta_eta
+            print("PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Average eta = ", avg_eta)
+            print("PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Maximum delta_eta = ", max_delta_eta)
+            print("PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Minimum delta_eta = ", min_delta_eta)
+            print("PE[",ags.myid,"] Edge string(",ags.adcircedgestringid,"): Average delta_eta = ", avg_delta_eta)
 
         if ags.couplingtype == 'gdAdg':
             DT = 0.0
@@ -88,7 +88,7 @@ def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
         #    DT += ags.effectivegsshadt
         #if ags.couplingtype == 'gdAdg':
         #    DT += ags.effectivegsshadt
-        #print DT, DT/86400.0
+        #print(DT, DT/86400.0)
 
         # Shift the time series
         for i in range(ts.num_vals-1):
@@ -132,11 +132,11 @@ def gssha_set_bc_from_adcirc_depths(ags): # ags is of type adcircgsshatruct.
         ts.jul_time[ts.num_vals-1] += ts.jul_time[ts.num_vals-3]-ts.jul_time[ts.num_vals-4]
 
     if (ags.pu.debug ==ags.pu.on or gsshaopts._DEBUG == gsshadefine.ON) and DEBUG_LOCAL != 0 and ags.myid == 0:
-        print 'Current GSSHA julian time =', ags.mvs[0].btime
+        print('Current GSSHA julian time =', ags.mvs[0].btime)
         #assert(ags.mvs[0].btime <= ts.jul_time[ts.num_vals-2])
         #assert(ags.mvs[0].btime >= ts.jul_time[0])
         for i in range(ts.num_vals):
-            print'After :(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')'
+            print('After :(t,v)[',i,'] = (', ts.jul_time[i],',', ts.val[i],')')
 
 ############################################################################################################
 if __name__ == '__main__':

--- a/watercoupler/main.py
+++ b/watercoupler/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
@@ -7,54 +7,92 @@
 Main function of watercoupler, calling inititialize, run, and finalize.
 """
 
+from __future__ import absolute_import, print_function
+from sys import version_info as _version_info
 import time
-import ctypes as ct
+import ctypes as _ct
 
-import watercoupler_path
-from coupler.adcircgsshastruct import  adcircgsshastruct
+if (__package__ == 'watercoupler'):
+    from . import watercoupler_path as _watercoupler_path
+elif (__name__ == '__main__'):
+    import watercoupler_path as _watercoupler_path
+else:
+    from . import watercoupler_path as _watercoupler_path
+
+from watercoupler.coupler.adcircgsshastruct import  adcircgsshastruct
 
 ################################################################################
 DEBUG_LOCAL = 1
 
 __all__ = ['main'] # The only thing from this module to import if needed.
 
+#------------------------------------------------------------------------------#
+def _getargcargv():
+    '''Get argc and argv into Python 2 or 3 version-independently.
+
+    The Py_GetArgcArgv function returns argv[i] as c_wchar_p in Python 3x and
+    c_char_p in Python 2x. We need them to be of type c_char_p since that is the
+    correct equivalent to a NULL terminated string, char *, in C.
+    '''
+
+    argc = _ct.c_int()
+    if (_version_info < (3, 0)):
+        # Python 2x
+        argv = _ct.POINTER(_ct.c_char_p)()
+        _ct.pythonapi.Py_GetArgcArgv(_ct.byref(argc), _ct.byref(argv))
+    else:
+        # Python 3x
+        argw = _ct.POINTER(_ct.c_wchar_p)()
+        _ct.pythonapi.Py_GetArgcArgv(_ct.byref(argc), _ct.byref(argw))
+        argv = (_ct.c_char_p*argc.value)()
+        for i in range(argc.value):
+            argv[i] = argw[i].encode()
+        argv = _ct.cast(argv, _ct.POINTER(_ct.c_char_p))
+
+    return argc, argv
+
 ################################################################################
 def main():
     """Main function of watercoupler.
 
     Requires 4 command line arguments.
-    The format is : python watercoupler.py \\
+    The format is : python -m watercoupler \\
                         <coupled ADCIRC edge string ID> \\
                         <coupling type identifier> \\
                         <GSSHA project file name> \\
                         <ADCIRC input file names without extension>
-    Coupling type identifier is one of: gdA, Adg, AdgdA, gdAdg
+    Coupling type identifier is one of: gdA, Adg, AdgdA, gdAdg.
     """
 
-    argv = ct.POINTER(ct.c_char_p)()
-    argc = ct.c_int()
-    ct.pythonapi.Py_GetArgcArgv(ct.byref(argc), ct.byref(argv))
+    argc, argv = _getargcargv()
 
-    if DEBUG_LOCAL == 1:
-        print 'Number of arguments passed to python:', argc.value, '\nArgs:',
-        for i in range(argc.value):
-            print argv[i],
-        print
-    if (argc.value<6) or (argv[argc.value-3] not in ['gdA', 'Adg', 'gdAdg', 'AdgdA']):
-        print "\nProblem with command line arguments."
-        print "Format is : python <*.py> <coupled ADCIRC edge string ID> <coupling type> <GSSHA model> <ADCIRC model>"
-        print "Coupling type options are: gdA, Adg, AdgdA, gdAdg"
-        print "Exiting without testing."
+    if (DEBUG_LOCAL == 1):
+        print('Number of arguments passed to python: {0} \nArgs:'.format(
+            argc.value), end = '')
+        [print(argv[i], end = ' ') for i in range(argc.value)]
+        print()
+    if (_version_info < (3, 0)):
+        couplingtype = argv[argc.value-3]
+    else:
+        couplingtype = str(argv[argc.value-3], 'utf-8')
+    if (argc.value<6) or (couplingtype not in ['gdA', 'Adg', 'gdAdg', 'AdgdA']):
+        print("\nProblem with command line arguments.")
+        print("Format is : python -m watercoupler "
+                "<coupled ADCIRC edge string ID> <coupling type> "
+                "<GSSHA model> <ADCIRC model>")
+        print("Coupling type options are: gdA, Adg, AdgdA, gdAdg")
+        print("Exiting without testing.")
         return -1
 
-    print "Coupling type :", argv[argc.value-3]
-    print "ADCIRC project:", argv[argc.value-1], ", coupled edge string ID", argv[argc.value-4]
-    print "GSSHA project :", argv[argc.value-2]
+    print("Coupling type :", argv[argc.value-3])
+    print("ADCIRC project: {0}, coupled edge string ID {1}".format(
+            argv[argc.value-1], argv[argc.value-4]))
+    print("GSSHA project :", argv[argc.value-2])
 
     t0 = time.time()
     print("Initializing watercoupler")
     ags = adcircgsshastruct()
-    ags.coupler_initialize(argc, argv)
+    ags.coupler_initialize(couplingtype, argc, argv)
 
     t1 = time.time()
     print("Running watercoupler")

--- a/watercoupler/watercoupler_path.py
+++ b/watercoupler/watercoupler_path.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #------------------------------------------------------------------------------#
 # watercoupler - Software for coupling hydrodynamic and hydrologic software
 # LICENSE: BSD 3-Clause "New" or "Revised"
 #------------------------------------------------------------------------------#
-"""
-Module for setting the path to the GSSHA and ADCIRC Python interfaces.
-"""
+"""Context module of watercoupler."""
+
 import os
 import sys
-sys.path.insert(0, '/workspace/gajanan/postdoc_2019/adcirc_v52-cg/work/')
-sys.path.insert(0, '/workspace/gajanan/pettt_2018/gssha/')
+
+sys.path.insert(0,os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
Mostly needed to fix imports, print statements and bytes/UTF string incompatibilities between Python 2 and 3 for this merge request.

MPI calls were also fixed, though water coupler currently does not work in parallel.